### PR TITLE
add SSR Guard. Extract Media into in-house component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # react-media-match
+====
+[![Build Status](https://travis-ci.org/thearnica/react-media-match.svg?branch=master)](https://travis-ci.org/thearnica/react-media-match)
+[![coverage-badge](https://img.shields.io/codecov/c/github/thearnica/react-media-match.svg?style=flat-square)](https://codecov.io/github/thearnica/react-media-match)
+[![NPM version](https://img.shields.io/npm/v/react-media-match.svg)](https://www.npmjs.com/package/react-media-match)
 
-[![NPM](https://nodei.co/npm/react-media-match.png?downloads=true&stars=true)](https://nodei.co/npm/react-media-match/)
 
-__Mobile first__ react responsive framework made easy. The main difference from `react-media` - everything.
+__Mobile first__ react responsive framework made easy. 
 
-Define once all your media queries (2-3-4 usual), and them use them _simultaneously_!
-Define how application should look like on all resolutions.
+ - 🐍 "gap" less. In all the cases one display mode will be picked up, but only one
+ - 💻 SSR friendly. Customize the target rendering mode, and generate result for any devide.
+ - 💡 Provides Media Matchers and Media Pickers
+ - 🧠 written in TypeScript
+
+Just:
+1. Define once all your media queries (2-3-4 usual), and them use them _simultaneously_!
+2. Define how application should look like on all resolutions. 
 
 Each Media Query is responsible only for a single "dimension" - width, height or orientation.
 - If you have defined what Query should render on _mobile_, but not everything else - it will always use mobile.
@@ -16,7 +25,7 @@ Each Media Query is responsible only for a single "dimension" - width, height or
 - If you need to respond to screen size and orientation - create 2 separate matchers, and work with them - separately!
 - If you need to respond to NOT screen or NOT media - just _provide_ values MediaMatcher should match againts and that's done!
 
-react-media-match was made with maintanability and mobile first approach in mind. It makes things simpler.
+react-media-match was made with maintainability and mobile first approach in mind. It makes things simpler.
 
 react-media-match provides 2 components and one function, and no of them awaits query as a prop,
 
@@ -48,6 +57,28 @@ react-media-match provides 2 components and one function, and no of them awaits 
 ```
 PS: Dont forget to __wrap all this with ProvideMediaMatchers__
 
+## Server Side Rendering
+There is no way to support MediaQuery on the Server Side, so the only way to generate expected result
+it __to mock__ predicted device.
+
+We are providing a special component which will mock data only on server size,
+and compare predicted media on componentMount on client size.
+
+It also has a special prop `hydrated` which will lead to __forced react tree remount__
+in case prediction was wrong, and rendered tree will not match hydrated one.
+(use only in case of `ReactDOM.hydrated`)
+ 
+```js
+<MediaServerRender predicted="desktop" hydrated>
+    <MediaMatcher
+        mobile={"render for mobile"}
+        // tablet={"tablet"} // mobile will be rendered for missed tablet
+        desktop={"render desktop"}
+    />
+</MediaServerRender>
+```
+If prediction has failed - it will inform you.
+
 ## API
  react-media-match provides an API for "default" queries, and a factory method to create custom media queries.
 
@@ -58,6 +89,7 @@ PS: Dont forget to __wrap all this with ProvideMediaMatchers__
    - Matcher
    - Provider
    - Mock
+   - SSR
 
  There is also pre-exported API for default breakpoints - mobile, tablet, desktop
 
@@ -68,6 +100,8 @@ PS: Dont forget to __wrap all this with ProvideMediaMatchers__
  - `MediaMatches` - component, returns current matchers as a render prop
 
  - `MediaMatcher` - component, renders path for active match
+ 
+ - `MediaServerRender` - component, helps render server-size
 
 # Example
  - Define secondary Query for orientation
@@ -97,7 +131,6 @@ PS: Dont forget to __wrap all this with ProvideMediaMatchers__
      ....
  </Orientation.Mock>
  ```
-
 
 ## Sandbox
 

--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {create} from 'react-test-renderer';
-import {MediaMatcher, MediaMock, pickMatch} from '../src';
+import {MediaMatcher, MediaMock, pickMatch, MediaServerRender} from '../src';
 
 describe('Specs', () => {
   it('should render mobile', () => {
@@ -82,5 +82,46 @@ describe('Specs', () => {
       tablet: 2,
       desktop: 3,
     })).toBe(1);
+  })
+
+
+  describe('SSR', () => {
+    it('Render', () => {
+      const wrapper =
+        create(
+          <MediaServerRender predicted="tablet">
+            <MediaMatcher mobile="1" tablet="2" desktop="3"/>
+          </MediaServerRender>
+        );
+      expect(wrapper.toJSON()).toEqual("2");
+    });
+
+    it('Render:positive', () => {
+      jest.spyOn(console, 'error');
+      const wrapper =
+        create(
+          <MediaMock tablet>
+          <MediaServerRender predicted="tablet">
+            <MediaMatcher mobile="1" tablet="2" desktop="3"/>
+          </MediaServerRender>
+          </MediaMock>
+        );
+      expect(wrapper.toJSON()).toEqual("2");
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it.skip('Render:negative', () => {
+      jest.spyOn(console, 'error');
+      const wrapper =
+        create(
+          <MediaMock desktop>
+            <MediaServerRender predicted="tablet">
+              <MediaMatcher mobile="1" tablet="2" desktop="3"/>
+            </MediaServerRender>
+          </MediaMock>
+        );
+      expect(wrapper.toJSON()).toEqual("2");
+      expect(console.error).toHaveBeenCalled();
+    });
   })
 });

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import {Component} from 'react';
 import {
-    ProvideMediaMatchers,
-    MediaMatcher,
-    InlineMediaMatcher,
-    pickMatch,
-    MediaMatches,
-    MediaMock,
-    createMediaMatcher
+  ProvideMediaMatchers,
+  MediaMatcher,
+  InlineMediaMatcher,
+  pickMatch,
+  MediaMatches,
+  MediaMock,
+  MediaServerRender,
+  createMediaMatcher
 } from "../src";
 
 export interface AppState {
@@ -15,59 +16,114 @@ export interface AppState {
 }
 
 const SecodaryMedia = createMediaMatcher({
-    'mobile': '(max-width: 600px)',
-    'tablet': '(max-width: 900px)',
-    'desktop': '(min-width: 700px)',
+  'mobile': '(max-width: 600px)',
+  'tablet': '(max-width: 900px)',
+  'desktop': '(min-width: 700px)',
 })
 
+let cntcnt=0;
+
+class Counter extends React.Component {
+  private cnt = 1
+
+  render(){
+    return <span>{this.cnt++} {cntcnt++}</span>;
+  }
+}
+
 export default class App extends Component <{}, AppState> {
-    state: AppState = {}
+  state: AppState = {}
 
-    render() {
-        return (
-            <ProvideMediaMatchers>
-                <div>
-                    displaying all 3:
-                    <MediaMatcher
-                        mobile={"mobile"}
-                        tablet={"tablet"}
-                        desktop={"desktop"}
-                    />
-                    <InlineMediaMatcher
-                        mobile={"mobile"}
-                        tablet={"tablet"}
-                        desktop={"desktop"}
-                    />
-                    <MediaMatches>
-                        {matches => (
-                            <span> testing {pickMatch(matches, {
-                                mobile: "mobile",
-                                tablet: "tablet",
-                                desktop: "desktop",
-                            })}</span>
-                        )}
-                    </MediaMatches>
-                    <br/>
-                    <MediaMock tablet={true}>
-                        always tablet:
-                        <MediaMatcher
-                            mobile={"mobile"}
-                            tablet={"tablet"}
-                            desktop={"desktop"}
-                        />
-                    </MediaMock>
+  render() {
+    return (
+      <ProvideMediaMatchers>
+        <div>
+          displaying all 3 (should be the same, and reflect active media):
+          <br/>
+          <MediaMatcher
+            mobile={"mobile"}
+            tablet={"tablet"}
+            desktop={"desktop"}
+          />|
+          <InlineMediaMatcher
+            mobile={"mobile"}
+            tablet={"tablet"}
+            desktop={"desktop"}
+          />|
+          <MediaMatches>
+            {matches => (
+              <span> = {pickMatch(matches, {
+                mobile: "mobile",
+                tablet: "tablet",
+                desktop: "desktop",
+              })}</span>
+            )}
+          </MediaMatches>
 
-                </div>
-                <div>
-                <SecodaryMedia.Provider>
-                    <SecodaryMedia.Matcher
-                       mobile="m-NEVER VISIBLE"
-                       tablet={ <MediaMatcher mobile="m" tablet="t" desktop="d" />}
-                       desktop="d-NEVER VISIBLE"
-                    />
-                </SecodaryMedia.Provider>
-                </div>
-            </ProvideMediaMatchers>
-        )
-    }
+          <br/>
+          tablet as maximum:
+          <br/>
+          <MediaMatcher
+            mobile={"mobile"}
+            tablet={"tablet"}
+          />|
+          <InlineMediaMatcher
+            mobile={"mobile"}
+            tablet={"tablet"}
+          />|
+          <MediaMatches>
+            {matches => (
+              <span> = {pickMatch(matches, {
+                mobile: "mobile",
+                tablet: "tablet",
+              })}</span>
+            )}
+          </MediaMatches>
+
+          <br/><br/>
+          While this should always be tablet (it is mocked):
+          <MediaMock tablet={true}>
+            <MediaMatcher
+              mobile={"mobile"}
+              tablet={"tablet"}
+              desktop={"desktop"}
+            />
+          </MediaMock>
+
+        </div>
+        <br/><br/>
+        Overlapping
+        <div>
+          <SecodaryMedia.Provider>
+            <SecodaryMedia.Matcher
+              mobile={<span>m<MediaMatcher mobile="m" tablet="t" desktop="d"/></span>}
+              tablet={<span>t<MediaMatcher mobile="m" tablet="t" desktop="d"/></span>}
+              desktop={<span>d<MediaMatcher mobile="m" tablet="t" desktop="d"/></span>}
+            />
+          </SecodaryMedia.Provider>
+        </div>
+
+        SSR
+        <div>
+          <MediaServerRender predicted="desktop">
+            <MediaMatcher
+              mobile={<span>mobile<Counter/></span>}
+              tablet={<span>tablet<Counter/></span>}
+              desktop={<span>desktop<Counter/></span>}
+            />
+          </MediaServerRender>
+        </div>
+
+        <div>
+          <MediaServerRender predicted="desktop" hydrated>
+            <MediaMatcher
+              mobile={<span>mobile<Counter/></span>}
+              tablet={<span>tablet<Counter/></span>}
+              desktop={<span>desktop<Counter/></span>}
+            />
+          </MediaServerRender>
+        </div>
+      </ProvideMediaMatchers>
+    )
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   "repository": "",
   "dependencies": {
     "prop-types": "^15.6.1",
-    "react-gearbox": "^1.1.2",
-    "react-media": "^1.8.0"
+    "react-gearbox": "^1.1.2"
   },
   "devDependencies": {
     "@types/prop-types": "^15.5.3",

--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+
+export interface MediaProps {
+  query: string,
+  children: (match: boolean | undefined) => React.ReactNode;
+}
+
+export class Media extends React.Component<MediaProps, {
+  matches: (boolean | undefined)
+}> {
+
+  state = {
+    matches: undefined as any
+  };
+
+  mediaQueryList: MediaQueryList | null = null;
+
+  constructor(props: MediaProps) {
+    super(props);
+
+    if (typeof window !== "object" || !window.matchMedia) return;
+
+    this.mediaQueryList = window.matchMedia(this.props.query);
+    this.state.matches = this.mediaQueryList.matches;
+  }
+
+  updateMatches = () => this.setState({matches: this.mediaQueryList!.matches});
+
+  componentDidMount() {
+    if (this.mediaQueryList) {
+      this.mediaQueryList.addListener(this.updateMatches);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.mediaQueryList) {
+      this.mediaQueryList.removeListener(this.updateMatches);
+    }
+  }
+
+  render() {
+    const {children} = this.props;
+    const {matches} = this.state;
+
+    return children(matches)
+  }
+}

--- a/src/SSR.tsx
+++ b/src/SSR.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+const PassThrought: any = ({children}: { children: React.ReactNode }) => children;
+
+export class MediaServerSide extends React.Component<{
+  predicted: string,
+  fact: string,
+  hydrated: boolean;
+  children: React.ReactNode
+}, {
+  key: string
+}> {
+  state = {
+    key: 'media-as-predicted'
+  };
+
+  componentDidMount() {
+    const {fact, predicted, hydrated } = this.props;
+    if (fact && fact !== predicted) {
+      if(hydrated) {
+        this.setState({
+          key: 'media-prediction-failed'
+        })
+      }
+      console.error(`React-media-match: SSR failed "${predicted}" was predicted, while "${fact}" seen by fact.`)
+    }
+  }
+
+  render() {
+    return <PassThrought key={this.state.key}>{this.props.children}</PassThrought>
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,11 @@ const Matches = defaultMedia.Gearbox;
 
 const MediaMock = defaultMedia.Mock;
 
+/**
+ * ServerSide rendering helper
+ */
+const MediaServerRender = defaultMedia.ServerRender;
+
 
 export {
     createMediaMatcher,
@@ -54,6 +59,8 @@ export {
     InlineMediaMatcher,
 
     MediaMatcher,
+
+    MediaServerRender,
 
     Matches,
     MediaMock

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,17 +4,7 @@ export type RenderMatch<T> = (matches: BoolOf<T>) => ReactNode;
 
 export type ObjectOf<T, K> = { [P in keyof T]: K };
 
-export interface IMediaQuery {
-    minWidth: number;
-    maxWidth: number;
-    screen: boolean;
-    handheld: boolean;
-    aspectRatio: number,
-    resolution: string;
-    orientation: 'landscape' | 'portrait'
-}
-
-export type MediaRule = string | IMediaQuery;
+export type MediaRule = string;
 
 export type MediaRulesOf<T> = ObjectOf<T, MediaRule>;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,48 +2,74 @@ import {MediaRulesOf, ObjectOf, BoolOf} from "./types";
 
 export function forEachName<T, K, R = {[key in keyof T]: K}>
 (object: MediaRulesOf<T>, map: (key: string) => K): R {
-    return Object
-        .keys(object)
-        .map(key => ({key, value: map(key)}))
-        .reduce((acc: any, line): R => ({
-            ...acc,
-            [line.key]: line.value
-        }), {})
+  return Object
+    .keys(object)
+    .map(key => ({key, value: map(key)}))
+    .reduce((acc: any, line): R => ({
+      ...acc,
+      [line.key]: line.value
+    }), {})
+}
+
+export function getMaxMatch<T>(mediaRules: MediaRulesOf<T>, matches: BoolOf<any>): string {
+  const keys = Object.keys(mediaRules);
+  const len = keys.length;
+
+  let index = 0;
+  for (; index < len; index++) {
+    if (matches[keys[index]]) {
+      break;
+    }
+  }
+
+  return keys[index];
 }
 
 export function pickMediaMatch<T, K>
 (mediaRules: MediaRulesOf<T>, matches: BoolOf<any>, slots: Partial<ObjectOf<any, K>>): K | null {
-    const keys = Object.keys(mediaRules);
-    const len = keys.length;
-
-    let index = 0;
-    for (; index < len; index++) {
-        if (matches[keys[index]]) {
-            break;
-        }
+  const keys = Object.keys(mediaRules);
+  const len = keys.length;
+  
+  let index = 0;
+  for (; index < len; index++) {
+    if (matches[keys[index]]) {
+      break;
     }
+  }
 
-    for (; index >= 0; index--) {
-        const value = slots[keys[index]];
-        if (value !== undefined) {
-            return value;
-        }
+  for (; index >= 0; index--) {
+    const value = slots[keys[index]];
+    if (value !== undefined) {
+      return value;
     }
+  }
 
-    return null;
+  return null;
 }
 
 export type Names = {
-    [key: string]: any;
+  [key: string]: any;
 }
 
 export function pickMatchValues(points: Names, props: Names) {
-    return Object
-        .keys(props)
-        .reduce((acc: any, key: string) => {
-            if (points[key] !== undefined) {
-                acc[key] = props[key];
-            }
-            return acc;
-        }, {})
+  return Object
+    .keys(props)
+    .reduce((acc: any, key: string) => {
+      if (points[key] !== undefined) {
+        acc[key] = props[key];
+      }
+      return acc;
+    }, {})
+}
+
+export function notNulls(matches: { [key: string]: boolean | undefined }): { [key: string]: boolean | undefined } {
+  return Object
+    .keys(matches)
+    .reduce((acc: any, key) => {
+      if (matches[key] !== undefined) {
+        acc[key] = matches[key]
+      }
+
+      return acc;
+    }, {})
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4466,12 +4466,6 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json2mq@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
-  dependencies:
-    string-convert "^0.2.0"
-
 json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -5798,7 +5792,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -5977,14 +5971,6 @@ react-is@^16.3.1, react-is@^16.3.2:
 react-is@^16.4.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
-
-react-media@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/react-media/-/react-media-1.8.0.tgz#b86d6d62313f95d53af7d06e23d4f49adfb131d3"
-  dependencies:
-    invariant "^2.2.2"
-    json2mq "^0.2.0"
-    prop-types "^15.5.10"
 
 react-reconciler@^0.7.0:
   version "0.7.0"
@@ -6823,10 +6809,6 @@ stream-to-observable@^0.2.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-
-string-convert@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR:
1. Get rid of React-media. It does not support React 16 strict mode, and super HUGE. In-house implementation of Media is 100 times smaller, and works better with future React.
2. Adds a new component for SSR, which will help to render `predicted` media on server, and help to `rehydrate` it on client, or force-update whole tree, if something went wrong.