### PR TITLE
expose pickMedia as renderProp

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ react-media-match provides 2 components and one function, and no of them awaits 
             }</span>
         )}
     </MediaMatches>
+    
+    <MediaMatches> // will provide matches information via render-props
+            {(_,pickMatch) => ( // you can get pickMatch from MediaMatches
+                <span> testing {
+                    // pick matching values
+                    pickMatch({
+                        mobile: "mobile",
+                        // tablet: "tablet", // the same rules are applied here
+                        desktop: "desktop",
+                    })
+                }</span>
+            )}
+        </MediaMatches>
 </ProvideMediaMatchers>
 ```
 PS: Dont forget to __wrap all this with ProvideMediaMatchers__ - without it will always picks the "last" branch.
@@ -81,6 +94,11 @@ in case prediction was wrong, and rendered tree will not match hydrated one.
 </MediaServerRender>
 ```
 If prediction has failed - it will inform you, and might help to mitigate rendering issues.
+
+#### How to predict device type
+You may use [ua-parser-js](https://github.com/faisalman/ua-parser-js), to detect device type, and pick desired resolution 
+based on this, or use [react-ugent](https://github.com/medipass/react-ugent) to make it a bit
+more declarative.
 
 ## API
  react-media-match provides an API for "default" queries, and a factory method to create custom media queries.

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -58,6 +58,15 @@ export default class App extends Component <{}, AppState> {
                 desktop: "desktop",
               })}</span>
             )}
+          </MediaMatches> ===
+          <MediaMatches>
+            {(_,pickMatch) => (
+              <span> = {pickMatch({
+                mobile: "mobile",
+                tablet: "tablet",
+                desktop: "desktop",
+              })}</span>
+            )}
           </MediaMatches>
 
           <br/>
@@ -105,6 +114,8 @@ export default class App extends Component <{}, AppState> {
 
         SSR
         <div>
+
+
           <MediaServerRender predicted="desktop">
             <MediaMatcher
               mobile={<span>mobile<Counter/></span>}
@@ -112,6 +123,8 @@ export default class App extends Component <{}, AppState> {
               desktop={<span>desktop<Counter/></span>}
             />
           </MediaServerRender>
+
+
         </div>
 
         <div>

--- a/src/createMediaMatcher.tsx
+++ b/src/createMediaMatcher.tsx
@@ -71,8 +71,10 @@ export function createMediaMatcher<T>(breakPoints: MediaRulesOf<T>) {
     override: PropTypes.bool
   };
 
-  const MediaMatches: React.SFC<{ children: RenderMatch<T> }> = ({children}) => (
-    <MediaContext.Consumer>{matched => children(matched as BoolOf<T>)}</MediaContext.Consumer>
+  const MediaMatches: React.SFC<{ children: RenderMatch<T, any> }> = ({children}) => (
+    <MediaContext.Consumer>
+      {matched => children(matched as BoolOf<T>, (matches) => pickMatch(matched as BoolOf<T>, matches))}
+    </MediaContext.Consumer>
   );
 
   MediaMatches.propTypes = {

--- a/src/custom-typings/react-adopt.d.ts
+++ b/src/custom-typings/react-adopt.d.ts
@@ -1,1 +1,0 @@
-declare module 'ereact-adopt';

--- a/src/custom-typings/react-media.d.ts
+++ b/src/custom-typings/react-media.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-media';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import {ReactNode} from "react";
 
-export type RenderMatch<T> = (matches: BoolOf<T>) => ReactNode;
+export type RenderMatch<T, K> = (matches: BoolOf<T>, pickMatch: (matches: Partial<ObjectOf<T, K>>) => K) => ReactNode;
 
 export type ObjectOf<T, K> = { [P in keyof T]: K };
 


### PR DESCRIPTION
### Features
 expose pickMedia as second argument of MediaMatches

I think the current way to use `pickMedia` is a bit overcomplicated.
```js
<MediaMatches> // will provide matches information via render-props
        {matches => 
                pickMatch(matches, {
                    mobile: "mobile",
                })
        }
    </MediaMatches>
```
is a bit, you know, verbose.
```js
<MediaMatches> // will provide matches information via render-props
        {(_, pickMatch) => 
                pickMatch({
                    mobile: "mobile",
                })
        }
    </MediaMatches>
```
Is much more clear and error prone.