### PR TITLE
feat: expose internal context to be used in static methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ PS: Don’t forget to __wrap all this with ProvideMediaMatchers__ - without it M
    - Provider
    - Mock
    - SSR
+   - Consumer
 
  There is also pre-exported API for default breakpoints - mobile, tablet, desktop
 
@@ -111,13 +112,15 @@ PS: Don’t forget to __wrap all this with ProvideMediaMatchers__ - without it M
 
  - `MediaMatches` - component, returns current matchers as a render prop
 
- - `MediaMatcher` - component, renders path for active match
+ - `MediaMatcher` - component, renders path for active match 
  
  - `Above` - component, render children above specified point. Or including specified point if `including` prop is set. 
  
  - `Below` - component, render children below specified point. Or including specified point if `including` prop is set.
 
  - `MediaServerRender` - component, helps render server-size
+ 
+ - `MediaConsumer` - React Context Consumer
 
 ## Example
  - Define secondary Query for orientation
@@ -151,6 +154,27 @@ import { createMediaMatcher } from "react-media-match";
      ....
  </Orientation.Mock>
  ```
+ 
+### Usage in life cycle events
+> Requires React16.6+
+```js
+import {MediaConsumer, pickMatch} from 'react-media-match';
+// use createMediaMatcher to create your own matches
+
+class App extends React.Component {
+  
+  // provide Consumer as a contextType
+  static contextType = MediaConsumer;
+  
+  componentDidMount() {
+    // use `pickMatch` matching the consumer
+    pickMatch(this.context, {
+      mobile: 'a',
+      tablet: 'b'
+    })
+  }
+}
+``` 
  
 ## Server-Side Rendering
 

--- a/src/createMediaMatcher.tsx
+++ b/src/createMediaMatcher.tsx
@@ -34,6 +34,7 @@ export type MediaMatcherType<T> = {
   ServerRender: React.SFC<{ predicted: keyof T, hydrated?: boolean, children: React.ReactNode }>,
 
   Gearbox: React.Consumer<BoolHash>,
+  Consumer: React.Consumer<BoolHash>,
 }
 
 export function createMediaMatcher<T>(breakPoints: MediaRulesOf<T>): MediaMatcherType<T> {
@@ -136,6 +137,7 @@ export function createMediaMatcher<T>(breakPoints: MediaRulesOf<T>): MediaMatche
     Matcher: MediaMatcher,
     ServerRender,
     //
-    Gearbox: MediaContext.Consumer
+    Gearbox: MediaContext.Consumer,
+    Consumer: MediaContext.Consumer
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,7 +38,7 @@ const MediaMatcher = defaultMedia.Matcher;
  * Calculates media match and returns via renderProps
  * @type {RPC<any, any>}
  */
-const Matches: React.Consumer<BoolOf<typeof mediaDefaults>> = defaultMedia.Gearbox as any;
+const Matches = defaultMedia.Matches;
 
 const MediaMock = defaultMedia.Mock;
 
@@ -56,6 +56,8 @@ const Above = defaultMedia.Above;
  * ServerSide rendering helper
  */
 const MediaServerRender = defaultMedia.ServerRender;
+
+const MediaConsumer = defaultMedia.Consumer;
 
 
 export {
@@ -75,5 +77,7 @@ export {
     MediaServerRender,
 
     Matches,
-    MediaMock
+    MediaMock,
+
+    MediaConsumer,
 }


### PR DESCRIPTION
## fix
 - `Matches` is `Matches`, not `Gearbox`

## feat
 - expose Context (not Gearbox, not Matches) to be used with React 16.6 contextType