### PR TITLE
feat: precompute media

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 __Mobile first__ react responsive framework made easy.
 
- - 🐍 "mobile-first", "gap-less", and bug-less rendering.
+ - 🐍 "mobile-first", "gap-less", and __bug-less__ rendering.
    - In all the cases one rendering branch will be picked, and only one!
    - Never forget to render something, never render two branches simultaneously.
  - 💻 SSR friendly. Customize the target rendering mode, and `SSR` for any device.
@@ -191,7 +191,36 @@ class App extends React.Component {
     })
   }
 }
-``` 
+```
+
+## Top level provider
+If you want to react to a _media change_ you __have__ to wrap your application with `ProvideMediaMatchers`.
+But if you don't - you might skip this moment.
+
+### For example - media for "device pointer type"
+Mobile phones(touch devices) don't have "hover" effects, while the onces with `mouse` - do support it.
+More of it - this could not be changed in runtime - device type is constant.
+
+This information might be quite important - for example you might control _autoFocus_, as long as 
+_auto-focusing_ input on a _touch_ device would open a `virtual keyboard`(consuming 50% of the screen), which may be
+not desired.
+
+In this case you might omit `ProvideMediaMatchers` and use _default_ values, which would be computed on start time.  
+```js
+const HoverMedia = createMediaMatcher({
+  touchDevice: "(hover: none)",
+  mouseDevice: "(hover: hover)",
+});
+
+const MyComponent = () => {
+  const autoFocus = HoverMedia.useMedia({
+    touchDevice: false,
+    mouseDevice: true,
+  });
+  
+  return <input autoFocus={autoFocus}/>
+}
+```
  
 ## Server-Side Rendering
 
@@ -218,7 +247,7 @@ import { MediaMatcher, MediaServerRender } from "react-media-match";
 ```
 If prediction has failed - it will inform you, and might help to mitigate rendering issues.
 
-#### How to predict device type
+#### How to predict a device type
 
 You may use [ua-parser-js](https://github.com/faisalman/ua-parser-js), to detect device type, and pick desired screen resolution, or use [react-ugent](https://github.com/medipass/react-ugent) to make it a bit
 more declarative. 

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -8,7 +8,7 @@ import {
   MediaMatches,
   MediaMock,
   MediaServerRender,
-  createMediaMatcher, Above, Below
+  createMediaMatcher, Above, Below,
   useMedia,
 } from "../src";
 
@@ -20,14 +20,19 @@ const SecodaryMedia = createMediaMatcher({
   'mobile': '(max-width: 600px)',
   'tablet': '(max-width: 900px)',
   'desktop': '(min-width: 700px)',
-})
+});
 
-let cntcnt=0;
+const HoverMedia = createMediaMatcher({
+  touchDevice: "(hover: none)",
+  mouseDevice: "(hover: hover)",
+});
+
+let cntcnt = 0;
 
 class Counter extends React.Component {
   private cnt = 1
 
-  render(){
+  render() {
     return <span>{this.cnt++} {cntcnt++}</span>;
   }
 }
@@ -42,13 +47,23 @@ const HookTest = () => {
   return <span>this is {displayedMedia}</span>;
 }
 
+const HoverHookTest = () => {
+  const displayedMedia = HoverMedia.useMedia({
+    touchDevice: 'touch',
+    mouseDevice: 'mouse',
+  });
+
+  return <span>this is {displayedMedia} (without provider)</span>;
+}
+
 export default class App extends Component <{}, AppState> {
   state: AppState = {}
 
   render() {
     return (
       <ProvideMediaMatchers>
-        <HookTest />
+        <HookTest/>
+        <HoverHookTest />>
         <div>
           <Above mobile>
             see me only ABOVE mobile
@@ -100,7 +115,7 @@ export default class App extends Component <{}, AppState> {
             )}
           </MediaMatches> ===
           <MediaMatches>
-            {(_,pickMatch) => (
+            {(_, pickMatch) => (
               <span> = {pickMatch({
                 mobile: "mobile",
                 tablet: "tablet",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   ],
   "repository": "https://github.com/thearnica/react-media-match",
   "dependencies": {
-    "prop-types": "^15.6.1"
+    "prop-types": "^15.6.1",
+    "tslib": "^1.9.3"
   },
   "size-limit": [
     {

--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -2,10 +2,12 @@ import * as React from "react";
 
 export type BoolHash = { [key: string]: boolean };
 
+export interface IQuery {
+  [key: string]: string;
+}
+
 export interface MediaProps {
-  queries: {
-    [key: string]: string;
-  },
+  queries: IQuery,
   children: (matches: BoolHash) => React.ReactNode;
 }
 
@@ -16,6 +18,20 @@ export interface MediaState {
   },
   keys: string[];
 }
+
+export const executeMediaQuery = (queries: IQuery) => {
+  const matches: BoolHash = {};
+  if (!(typeof window !== "object" || !window.matchMedia)) {
+    if (window) {
+      Object
+        .keys(queries)
+        .forEach(media => {
+          matches[media] = window.matchMedia(queries[media]).matches;
+        });
+    }
+  }
+  return matches;
+};
 
 export class Media extends React.Component<MediaProps, MediaState> {
 

--- a/src/createMediaMatcher.tsx
+++ b/src/createMediaMatcher.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import {Media, BoolHash} from './Media'
+import {Media, BoolHash, executeMediaQuery} from './Media'
 
 // @ts-ignore
 import {BoolOf, MediaRulesOf, ObjectOf, RenderMatch, RenderOf, IMediaQuery, Including} from "./types";
@@ -39,7 +39,7 @@ export type MediaMatcherType<T> = {
 }
 
 export function createMediaMatcher<T>(breakPoints: MediaRulesOf<T>): MediaMatcherType<T> {
-  const MediaContext = React.createContext<BoolHash>({});
+  const MediaContext = React.createContext<BoolHash>(executeMediaQuery(breakPoints));
 
   function pickMatch<K>(matches: BoolOf<T>, slots: Partial<ObjectOf<T, K>>): K | null {
     return pickMediaMatch<T, K>(breakPoints, matches, slots)


### PR DESCRIPTION
- Precompute state before creating `context` to enable "provider-free" usage
- update readme with an example