### PR TITLE
Change type of state prop in ProvideMediaMatchers

### DIFF
--- a/src/createMediaMatcher.tsx
+++ b/src/createMediaMatcher.tsx
@@ -54,7 +54,7 @@ export function createMediaMatcher<T>(breakPoints: MediaRulesOf<T>): MediaMatche
     return pickMediaMatch<T, React.ReactNode>(breakPoints, matches, slots)
   }
 
-  const ProvideMediaMatchers: React.SFC<{ state?: MediaRulesOf<T>, override?: false }> = ({children, state = null, override = false}) => (
+  const ProvideMediaMatchers: React.SFC<{ state?: BoolOf<T>, override?: false }> = ({children, state = null, override = false}) => (
     <MediaContext.Consumer>
       {parentMatch =>
         <Media queries={breakPoints}>


### PR DESCRIPTION
Change `state: MediaRulesOf<T>` to `state: BoolOf<T>` because `{'mobile': true, 'tablet': false, 'desktop': false}` is not assignable to MediaRulesOf<T> as this is no BoolHash