### PR TITLE
fix: computed matches got state with defaults provided

### DIFF
--- a/__tests__/ssr-mocks.tsx
+++ b/__tests__/ssr-mocks.tsx
@@ -5,6 +5,22 @@ import {
 } from '../src';
 
 describe('Specs', () => {
+  it('all false branches', () => {
+    const SideMatch = createMediaMatcher({
+      client: false,
+      server: false,
+    });
+
+    const wrapper =
+      create(
+        <SideMatch.Matcher
+          client="client"
+          server="server"
+        />
+      );
+    expect(wrapper.toJSON()).toEqual("server");
+  });
+
   it('emulate ClientSideOnly component', () => {
     const SideMatch = createMediaMatcher({
       client: false,

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -77,6 +77,7 @@ export default class App extends Component <{}, AppState> {
     return (
       <ProvideMediaMatchers>
         <HookTest/>
+
         <br/>
         <HoverHookTest/>
         <br/>
@@ -172,6 +173,18 @@ export default class App extends Component <{}, AppState> {
               tablet={"tablet"}
               desktop={"desktop"}
             />
+          </MediaMock>
+
+          <br/><br/>
+          And this also:
+          <MediaMock tablet={true}>
+            <ProvideMediaMatchers>
+              <MediaMatcher
+                mobile={"mobile"}
+                tablet={"tablet"}
+                desktop={"desktop"}
+              />
+            </ProvideMediaMatchers>
           </MediaMock>
 
         </div>

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -27,6 +27,11 @@ const HoverMedia = createMediaMatcher({
   mouseDevice: "(hover: hover)",
 });
 
+const FixedMedia = createMediaMatcher({
+  true: true,
+  false: false,
+});
+
 let cntcnt = 0;
 
 class Counter extends React.Component {
@@ -45,7 +50,7 @@ const HookTest = () => {
   });
 
   return <span>this is {displayedMedia}</span>;
-}
+};
 
 const HoverHookTest = () => {
   const displayedMedia = HoverMedia.useMedia({
@@ -54,16 +59,31 @@ const HoverHookTest = () => {
   });
 
   return <span>this is {displayedMedia} (without provider)</span>;
-}
+};
+
+const FixedHookTest = () => {
+  const fixed = FixedMedia.useMedia({
+    true: 'true',
+    false: 'false',
+  });
+
+  return <span>fixed {fixed}</span>;
+};
 
 export default class App extends Component <{}, AppState> {
-  state: AppState = {}
+  state: AppState = {};
 
   render() {
     return (
       <ProvideMediaMatchers>
         <HookTest/>
-        <HoverHookTest />>
+        <br/>
+        <HoverHookTest/>
+        <br/>
+        <FixedHookTest/>
+        <FixedMedia.Provider>
+          <FixedHookTest/>
+        </FixedMedia.Provider>
         <div>
           <Above mobile>
             see me only ABOVE mobile

--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -61,7 +61,7 @@ export class Media extends React.Component<MediaProps, MediaState> {
       .keys(queries)
       .forEach(media => {
         const query = queries[media];
-        if(typeof query === "string") {
+        if (typeof query === "string") {
           this.state.matches[media] = (this.state.matchers[media] = window.matchMedia(query)).matches;
         } else {
           this.state.matches[media] = query as boolean;
@@ -69,21 +69,25 @@ export class Media extends React.Component<MediaProps, MediaState> {
       });
   }
 
-  updateMatches = () => this.setState(({keys, matchers}) => ({
-    matches: keys.reduce((acc: BoolHash, key) => {
-      acc[key] = matchers[key].matches;
-      return acc;
-    }, {})
-  }));
+  updateMatches = () => (
+    this.setState(({keys, matchers, matches}) => ({
+      matches: keys.reduce((acc: BoolHash, key) => {
+        acc[key] = matchers[key].matches;
+        return acc;
+      }, {
+        ...matches
+      })
+    }))
+  );
 
   componentDidMount() {
-    const {keys, matchers} = this.state;
-    keys.forEach(key => matchers[key].addListener(this.updateMatches));
+    const {matchers} = this.state;
+    Object.keys(matchers).forEach(match => matchers[match].addListener(this.updateMatches));
   }
 
   componentWillUnmount() {
-    const {keys, matchers} = this.state;
-    keys.forEach(key => matchers[key].removeListener(this.updateMatches));
+    const {matchers} = this.state;
+    Object.keys(matchers).forEach(match => matchers[match].removeListener(this.updateMatches));
   }
 
   render() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,6 +79,17 @@ export function inBetween(breakPoints: Names, points: any, value: any, invert: b
     }, {})
 }
 
+export function nothingSet(matches: { [key: string]: any }): { [key: string]: boolean } {
+  return Object
+    .keys(matches)
+    .reduce((acc: any, key) => {
+      acc[key] = false;
+
+      return acc;
+    }, {})
+}
+
+
 export function notNulls(matches: { [key: string]: boolean | undefined }): { [key: string]: boolean } {
   return Object
     .keys(matches)


### PR DESCRIPTION
fixes: media matches do not update as long as defaults override new values (in Provider)