### PR TITLE
feat: tighten types using first key property

### DIFF
--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -130,6 +130,18 @@ describe('Specs', () => {
   });
 
   it('pickMatch', () => {
+    const try0 = pickMatch(
+      {
+        mobile: false,
+        tablet: false,
+        desktop: false,
+      },
+      {
+        mobile: { notUndefined: 'yes' },
+      }
+    );
+    expect(try0.notUndefined).toBe('yes');
+
     const try1 = pickMatch(
       {
         mobile: false,
@@ -137,10 +149,10 @@ describe('Specs', () => {
         desktop: false,
       },
       {
-        tablet: 2,
+        tablet: { notUndefined: 'yes' },
       }
     );
-    expect(try1).toBe(2);
+    expect(try1!.notUndefined).toBe('yes');
 
     const try2 = pickMatch(
       {

--- a/__tests__/types.ts
+++ b/__tests__/types.ts
@@ -1,0 +1,30 @@
+import { hover } from '../src/mediaVariants';
+
+describe('types', () => {
+  it('hover', () => {
+    const test1 = hover.pickMatch(
+      {
+        incapable: true,
+        capable: false,
+      },
+      {
+        incapable: { check: true },
+        capable: { check: false },
+      }
+    );
+
+    expect(test1.check).toBe(true);
+
+    const test2 = hover.pickMatch(
+      {
+        incapable: false,
+        capable: false,
+      },
+      {
+        capable: { check: false },
+      }
+    );
+
+    expect(test2!.check).toBe(false);
+  });
+});

--- a/src/createMediaMatcher.tsx
+++ b/src/createMediaMatcher.tsx
@@ -22,6 +22,8 @@ const castPointsTo = (points: { [key: string]: any }, targetType: any) =>
   }, {});
 
 const skipProp: any = {};
+// @ts-ignore
+const use = (...args: any[]) => null;
 
 /**
  * Creates a group media matcher
@@ -33,7 +35,16 @@ const skipProp: any = {};
  * });
  * @see https://github.com/thearnica/react-media-match#api
  */
-export function createMediaMatcher<T>(queries: MediaRulesOf<T>): MediaMatcherType<T> {
+export function createMediaMatcher<T extends object>(queries: MediaRulesOf<T>): MediaMatcherType<T, keyof T>;
+export function createMediaMatcher<T extends object, FirstKey extends keyof T = keyof T>(
+  queries: MediaRulesOf<T>,
+  firstKey: FirstKey
+): MediaMatcherType<T, FirstKey>;
+export function createMediaMatcher<T extends object, FirstKey extends keyof T = keyof T>(
+  queries: MediaRulesOf<T>,
+  firstKey?: FirstKey
+): MediaMatcherType<T, FirstKey> {
+  use(firstKey);
   const mediaDefaults = executeMediaQuery(queries);
   const initialValue = {} as any;
   const MediaContext = React.createContext<Partial<BoolOf<T>>>(initialValue);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import { createMediaMatcher } from './createMediaMatcher';
 import mediaDefaults from './mediaDefaults';
 
-const defaultMedia = createMediaMatcher(mediaDefaults);
+const defaultMedia = createMediaMatcher(mediaDefaults, 'mobile');
 
 /**
  * Picks value from Slots for matching Match)

--- a/src/mediaVariants.ts
+++ b/src/mediaVariants.ts
@@ -10,14 +10,17 @@ import { createMediaMatcher } from './createMediaMatcher';
  * - xl, extra-large: 1920px
  * @see https://material-ui.com/customization/breakpoints/
  */
-export const breakpoints = createMediaMatcher({
-  xxs: '(max-width: 359px)',
-  xs: '(max-width: 599px)',
-  ss: '(max-width: 959px)',
-  md: '(max-width: 1279px)',
-  lg: '(max-width: 1919px)',
-  xl: '(min-width: 1920px)',
-});
+export const breakpoints = createMediaMatcher(
+  {
+    xxs: '(max-width: 359px)',
+    xs: '(max-width: 599px)',
+    ss: '(max-width: 959px)',
+    md: '(max-width: 1279px)',
+    lg: '(max-width: 1919px)',
+    xl: '(min-width: 1920px)',
+  },
+  'xxs'
+);
 
 /**
  * device orientation (orientation)
@@ -25,34 +28,40 @@ export const breakpoints = createMediaMatcher({
  * - landscape
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/orientation
  */
-export const orientation = createMediaMatcher({
-  portrait: '(orientation: portrait)',
-  landscape: '(orientation: landscape)',
-});
+export const orientation = createMediaMatcher(
+  {
+    portrait: '(orientation: portrait)',
+    landscape: '(orientation: landscape)',
+  },
+  'portrait'
+);
 
 /**
  * hover capabilities (hover)
- * - capable (mouseDevice)
  * - incapable (touchDevice)
+ * - capable (mouseDevice)
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover
  */
-export const hover = createMediaMatcher({
-  touchDevice: '(hover: none)',
-  incapable: '(hover: none)',
-  capable: '(hover: hover)',
-  mouseDevice: '(hover: hover)',
-});
-
+export const hover = createMediaMatcher(
+  {
+    incapable: '(hover: none)',
+    capable: '(hover: hover)',
+  },
+  'incapable'
+);
 /**
  * dark mode (prefers-color-scheme)
  * - light
  * - dark
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
  */
-export const darkMode = createMediaMatcher({
-  light: true as any,
-  dark: '(prefers-color-scheme: dark)',
-});
+export const darkMode = createMediaMatcher(
+  {
+    light: true as any,
+    dark: '(prefers-color-scheme: dark)',
+  },
+  'light'
+);
 
 /**
  * reduced motion (prefers-reduced-motion)
@@ -60,7 +69,10 @@ export const darkMode = createMediaMatcher({
  * - reduce
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
  */
-export const reducedMotion = createMediaMatcher({
-  normal: true as any,
-  reduce: '(prefers-reduced-motion: reduce)',
-});
+export const reducedMotion = createMediaMatcher(
+  {
+    normal: true as any,
+    reduced: '(prefers-reduced-motion: reduce)',
+  },
+  'normal'
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,9 @@ export interface NoChildren {
   children?: never;
 }
 
-export interface MediaMatcherType<T> {
+export type WithRequiredKeysSet<T extends object, RequiredKey extends keyof T> = Partial<T> & Pick<T, RequiredKey>; // & Partial<Pick<T, Exclude<keyof T, RequiredKey>>>;
+
+export interface MediaMatcherType<T extends object, RequiredKey extends keyof T = keyof T> {
   /**
    * RenderProp component returning
    * - matches - a current state, an object passable to {@link pickMatch}
@@ -136,7 +138,7 @@ export interface MediaMatcherType<T> {
    *    }
    *  ); // == that's backend!
    */
-  pickMatch<K>(matches: BoolOf<T>, slots: ObjectOf<T, K>): K;
+  pickMatch<K>(matches: BoolOf<T>, slots: WithRequiredKeysSet<ObjectOf<T, K>, RequiredKey>): K;
   pickMatch<K>(matches: BoolOf<T>, slots: Partial<ObjectOf<T, K>>): K | undefined;
   pickMatch<K, DK extends K = K>(matches: BoolOf<T>, slots: Partial<ObjectOf<T, K>>, defaultValue: DK): K;
 
@@ -163,7 +165,7 @@ export interface MediaMatcherType<T> {
    *   xs: "not that small",
    * }, "small")
    */
-  useMedia<K>(slots: ObjectOf<T, K>): K;
+  useMedia<K>(slots: WithRequiredKeysSet<ObjectOf<T, K>, RequiredKey>): K;
   useMedia<K>(slots: Partial<ObjectOf<T, K>>): K | undefined;
   useMedia<K, DK extends K = K>(slots: Partial<ObjectOf<T, K>>, defaultValue: DK): K;
 }


### PR DESCRIPTION
The idea behind this change is to provide better types - in case of first placeholder is provided then matcher could not be resolved to undefined, and so should not.