### PR TITLE
feat: expose used queries

### DIFF
--- a/.size.json
+++ b/.size.json
@@ -2,6 +2,6 @@
   {
     "name": "dist/es2015/index.js",
     "passed": true,
-    "size": 2253
+    "size": 2255
   }
 ]

--- a/__tests__/types.ts
+++ b/__tests__/types.ts
@@ -40,4 +40,10 @@ describe('types', () => {
 
     expect(testDefault).toBe(true);
   });
+
+  describe('extra', () => {
+    it('exposes queries', () => {
+      expect(hover.queries.capable).toEqual('(hover: hover)');
+    });
+  });
 });

--- a/src/createMediaMatcher.tsx
+++ b/src/createMediaMatcher.tsx
@@ -44,17 +44,15 @@ const use = (...args: any[]) => null;
  * });
  * @see https://github.com/thearnica/react-media-match#api
  */
-export function createMediaMatcher<T extends object, MediaRules = MediaRulesOf<T>>(
-  queries: MediaRules
-): MediaMatcherType<T, keyof T, MediaRules>;
-export function createMediaMatcher<T extends object, FirstKey extends keyof T = keyof T, MediaRules = MediaRulesOf<T>>(
-  queries: MediaRules,
+export function createMediaMatcher<T extends object>(queries: MediaRulesOf<T>): MediaMatcherType<T, keyof T>;
+export function createMediaMatcher<T extends object, FirstKey extends keyof T = keyof T>(
+  queries: MediaRulesOf<T>,
   firstKey: FirstKey
-): MediaMatcherType<T, FirstKey, MediaRules>;
-export function createMediaMatcher<T extends object, FirstKey extends keyof T = keyof T, MediaRules = MediaRulesOf<T>>(
-  queries: MediaRules,
+): MediaMatcherType<T, FirstKey>;
+export function createMediaMatcher<T extends object, FirstKey extends keyof T = keyof T>(
+  queries: MediaRulesOf<T>,
   firstKey?: FirstKey
-): MediaMatcherType<T, FirstKey, MediaRules> {
+): MediaMatcherType<T, FirstKey> {
   use(firstKey);
   const mediaDefaults = executeMediaQuery(queries);
   const initialValue = {} as any;

--- a/src/createMediaMatcher.tsx
+++ b/src/createMediaMatcher.tsx
@@ -44,15 +44,17 @@ const use = (...args: any[]) => null;
  * });
  * @see https://github.com/thearnica/react-media-match#api
  */
-export function createMediaMatcher<T extends object>(queries: MediaRulesOf<T>): MediaMatcherType<T, keyof T>;
-export function createMediaMatcher<T extends object, FirstKey extends keyof T = keyof T>(
-  queries: MediaRulesOf<T>,
+export function createMediaMatcher<T extends object, MediaRules = MediaRulesOf<T>>(
+  queries: MediaRules
+): MediaMatcherType<T, keyof T, MediaRules>;
+export function createMediaMatcher<T extends object, FirstKey extends keyof T = keyof T, MediaRules = MediaRulesOf<T>>(
+  queries: MediaRules,
   firstKey: FirstKey
-): MediaMatcherType<T, FirstKey>;
-export function createMediaMatcher<T extends object, FirstKey extends keyof T = keyof T>(
-  queries: MediaRulesOf<T>,
+): MediaMatcherType<T, FirstKey, MediaRules>;
+export function createMediaMatcher<T extends object, FirstKey extends keyof T = keyof T, MediaRules = MediaRulesOf<T>>(
+  queries: MediaRules,
   firstKey?: FirstKey
-): MediaMatcherType<T, FirstKey> {
+): MediaMatcherType<T, FirstKey, MediaRules> {
   use(firstKey);
   const mediaDefaults = executeMediaQuery(queries);
   const initialValue = {} as any;
@@ -182,6 +184,7 @@ export function createMediaMatcher<T extends object, FirstKey extends keyof T = 
   );
 
   return {
+    queries,
     pickMatch,
     useMedia,
 

--- a/src/mediaDefaults.ts
+++ b/src/mediaDefaults.ts
@@ -1,5 +1,5 @@
 export default {
-    'mobile': '(max-width: 767px)',
-    'tablet': '(max-width: 1023px)',
-    'desktop': '(min-width: 1024px)',
-}
+  mobile: '(max-width: 767px)',
+  tablet: '(max-width: 1023px)',
+  desktop: '(min-width: 1024px)',
+} as const;

--- a/src/mediaVariants.ts
+++ b/src/mediaVariants.ts
@@ -2,12 +2,12 @@ import { createMediaMatcher } from './createMediaMatcher';
 
 /**
  * bootstrap breakpoints (max-width)
- * - xxs, extra-extra-small: 0px
- * - xs, extra-small: 359px
- * - sm, small: 600px
- * - md, medium: 960px
- * - lg, large: 1280px
- * - xl, extra-large: 1920px
+ * - xxs, extra-extra-small: 0px, a virtual starting point
+ * - xs, extra-small: 359px, the end of "small" phones
+ * - sm, small: 600px, theoretical start of tablets
+ * - md, medium: 960px, theoretical start of desktops
+ * - lg, large: 1280px, a normal desktop
+ * - xl, extra-large: 1920px, wide desktops
  * @see https://material-ui.com/customization/breakpoints/
  */
 export const breakpoints = createMediaMatcher(

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,13 +18,22 @@ export interface Including {
 
 export interface LeafComponent<P = {}> {
   (props: P): ReactElement<any, any> | null;
+
   propTypes?: WeakValidationMap<P>;
   displayName?: string;
 }
 
 export type WithRequiredKeysSet<T extends object, RequiredKey extends keyof T> = Partial<T> & Pick<T, RequiredKey>; // & Partial<Pick<T, Exclude<keyof T, RequiredKey>>>;
 
-export interface MediaMatcherType<T extends object, RequiredKey extends keyof T = keyof T> {
+export interface MediaMatcherType<
+  T extends object,
+  RequiredKey extends keyof T = keyof T,
+  MediaRules extends MediaRulesOf<T> = MediaRulesOf<T>
+> {
+  /**
+   * list of known matches
+   */
+  queries: MediaRules;
   /**
    * RenderProp component returning
    * - matches - a current state, an object passable to {@link pickMatch}

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,15 +25,11 @@ export interface LeafComponent<P = {}> {
 
 export type WithRequiredKeysSet<T extends object, RequiredKey extends keyof T> = Partial<T> & Pick<T, RequiredKey>; // & Partial<Pick<T, Exclude<keyof T, RequiredKey>>>;
 
-export interface MediaMatcherType<
-  T extends object,
-  RequiredKey extends keyof T = keyof T,
-  MediaRules extends MediaRulesOf<T> = MediaRulesOf<T>
-> {
+export interface MediaMatcherType<T extends object, RequiredKey extends keyof T = keyof T> {
   /**
    * list of known matches
    */
-  queries: MediaRules;
+  queries: MediaRulesOf<T>;
   /**
    * RenderProp component returning
    * - matches - a current state, an object passable to {@link pickMatch}
@@ -180,7 +176,7 @@ export interface MediaMatcherType<
    * third form of {@link pickMatch}
    * first "slot" is not provided, but there is a default value to use
    */
-  pickMatch<K, DK extends K = K>(matches: BoolOf<T>, slots: Partial<ObjectOf<T, K>>, defaultValue: DK): K;
+  pickMatch<K, DK>(matches: BoolOf<T>, slots: Partial<ObjectOf<T, K>>, defaultValue: DK): K | DK;
 
   /**
    * Matches the current media
@@ -217,5 +213,5 @@ export interface MediaMatcherType<
    * third form of {@link useMedia}
    * first "slot" is not provided, but there is a default value to use
    */
-  useMedia<K, DK extends K = K>(slots: Partial<ObjectOf<T, K>>, defaultValue: DK): K;
+  useMedia<K, DK>(slots: Partial<ObjectOf<T, K>>, defaultValue: DK): K | DK;
 }


### PR DESCRIPTION
Just want to be able access queries/targets/matches used to create a MediaMatcher